### PR TITLE
Updated util scripts

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -14,8 +14,10 @@ If your memory dump doesn't start from the PCSX2 elf base (usually 0x20000000), 
 
 There is a sample `mem.bin` file in this directory that you can use to test this script. It is small segment of memory from Cairo in the PAL version. The string table starts at offset `0x10`, and the memdump begins at 0x204BA440, so run the script with `python dump_string_table.py mem.bin 10 -s 4BA440`.
 
-[//]: <> (## check_pnach_compat.py)
+## check_pnach_compat.py
 
-[//]: <> (Usage: `python check_pnach_compat.py <path to first pnach> <path to second pnach>`)
+`python check_pnach_compat.py <path to first pnach> <path to second pnach>`
 
-[//]: <> (This script will check if two pnach files are compatible with each other. When run, it will ouput a list of all the addresses that are in both pnach files. If the pnach files are compatible, this list should be empty and it will tell you as much.)
+This script will check if two pnach files are compatible with each other. When run, it will ouput a list of all the addresses that are in both pnach files. If the pnach files are compatible, this list should be empty and it will tell you as much.
+
+Two pnach files are compatible if they don't both write to the same memory addresses (unless the writes are qualified by conditional statements that are mutually exclusive). In its current state, the script does not check for conditional statements and assumes that all writes are unconditional.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,21 @@
+# Utilities
+
+This folder contains some helpful utilities for working with strings and pnach files.
+
+## dump_string_table.py
+
+`python dump_string_table.py <path to ps2 memory dump> <offset to string table>`
+
+This script will dump the string table from a ps2 memory dump. It will output a file called `strings.csv` in the this directory. This is useful for finding the ID of a string you want to replace.
+
+If your memory dump doesn't start from the PCSX2 elf base (usually 0x20000000), use the `-s` or `--start` option to set the start offset of your memory dump. For example, if your memory dump is of the region from 0x20100000 to 0x20FFFFFF, use `-s 100000`.
+
+### Example
+
+There is a sample `mem.bin` file in this directory that you can use to test this script. It is small segment of memory from Cairo in the PAL version. The string table starts at offset `0x10`, and the memdump begins at 0x204BA440, so run the script with `python dump_string_table.py mem.bin 10 -s 4BA440`.
+
+[//]: <> (## check_pnach_compat.py)
+
+[//]: <> (Usage: `python check_pnach_compat.py <path to first pnach> <path to second pnach>`)
+
+[//]: <> (This script will check if two pnach files are compatible with each other. When run, it will ouput a list of all the addresses that are in both pnach files. If the pnach files are compatible, this list should be empty and it will tell you as much.)

--- a/utils/check_pnach_compat.py
+++ b/utils/check_pnach_compat.py
@@ -1,0 +1,82 @@
+"""
+Script for checking if two pnach files are compatible with each other.
+"""
+import argparse
+
+def get_addresses(pnach):
+    """
+    Gets the memory addresses that are written to by a pnach file.
+    """
+    lines = pnach.split('\n')
+    addresses = []
+
+    for line in lines:
+        if line.startswith("patch="):
+            code_part_1 = line.split(",")[2]
+            code_part_2 = line.split(",")[4]
+            code_type = code_part_1[0]
+
+            if code_type == "E":
+                # 16-bit test conditional
+                # E0nnvvvv taaaaaaa
+                # Compares value at address @a to value @v, and executes next @n code llines only if the test condition @t is true
+                address = int(code_part_2[1:8], 16)
+                value = int(code_part_1[4:8], 16)
+                num_lines = int(code_part_1[2:4], 16)
+                condition = code_part_1[1]
+            elif code_type == "2":
+                # 32-bit constant write
+                # 2aaaaaaa vvvvvvvv
+                # Constantly writes a 32-bit value @v to the address @a.
+                address = int(code_part_1[1:8], 16)
+                value = int(code_part_2[0:8], 16)
+                addresses.append(address)
+    
+    return addresses
+
+def check_compatiblity(pnach_1, pnach_2):
+    """
+    Checks if two pnach files are compatible with each other. Two pnach files
+    are compatible if they don't both write to the same memory addresses (unless
+    the writes are qualified by conditional statements that are mutually exclusive).
+
+    For the time being this script does not check for conditional statements and
+    assumes that all writes are unconditional.
+    """
+    # get the memory addresses that are written to by each pnach file
+    pnach_1_addresses = get_addresses(pnach_1)
+    pnach_2_addresses = get_addresses(pnach_2)
+    
+    # check if any of the addresses are written to by both pnach files
+    matches = []
+    for address in pnach_1_addresses:
+        if address in pnach_2_addresses:
+            matches.append(address)
+    
+    if len(matches) > 0:
+        matches_string = ", ".join([hex(match) for match in matches])
+        return f"The following {len(matches)} addresses are written to by both pnach files: {matches_string}"
+    else:
+        return "The pnach files are compatible!"
+
+def main():
+    # get the command line arguments
+    parser = argparse.ArgumentParser(description="Checks if two pnach files are compatible with each other.")
+    parser.add_argument("pnach_file_1", help="The first pnach file.")
+    parser.add_argument("pnach_file_2", help="The second pnach file.")
+    args = parser.parse_args()
+
+    # read the pnach files
+    pnach_1 = None
+    print(args)
+    with open(args.pnach_file_1, "r") as file:
+        pnach_1 = file.read()
+    pnach_2 = None
+    with open(args.pnach_file_2, "r") as file:
+        pnach_2 = file.read()
+
+    result = check_compatiblity(pnach_1, pnach_2)
+    print(result)
+
+if __name__ == "__main__":
+    main()

--- a/utils/dump_string_table.py
+++ b/utils/dump_string_table.py
@@ -1,14 +1,13 @@
 """
-Extracts the string table from a memory dump to a csv file.
+Script for extracting the string table from a ps2 memory dump to a csv file.
 """
 import argparse
 
 def dump_string_table(mem, string_table_start, mem_dump_start=0x00000000):
     """
-    Dumps the string IDs and strings to a csv file.
-    The string table is an array list of id/string pointer pairs.
+    Dumps the string table from a memory dump to a csv file.
+    The original string table is an array list of id/string pointer pairs.
     """
-
     with open("strings.csv", "w+", encoding="utf-8") as file:
         cur = string_table_start
         i = 0
@@ -41,9 +40,9 @@ def dump_string_table(mem, string_table_start, mem_dump_start=0x00000000):
 if __name__ == "__main__":
     # get the command line arguments
     parser = argparse.ArgumentParser(description="Extracts the string table from a memory dump to a csv file.")
-    parser.add_argument("mem_file", help="The memory dump file.")
-    parser.add_argument("offset", help="The start of the string table.", type=lambda x: int(x, 16))
-    parser.add_argument("-s", "--start", help="The start of the memory dump.", type=lambda x: int(x, 16), default=0x00000000)
+    parser.add_argument("mem-file", help="The PS2 memory dump file.")
+    parser.add_argument("offset", help="The start offset of the string table in the mem dump.", type=lambda x: int(x, 16))
+    parser.add_argument("-s", "--start", help="The start offset of the memory dump relative to the PS2 EE memory base.", type=lambda x: int(x, 16), default=0x00000000)
     args = parser.parse_args()
 
     # read the memory dump

--- a/utils/dump_string_table.py
+++ b/utils/dump_string_table.py
@@ -1,15 +1,15 @@
-"""Extracts the string table from a memory dump to a csv file."""
+"""
+Extracts the string table from a memory dump to a csv file.
+"""
+import argparse
 
-STRING_TABLE_START = 0x10
-
-def dump_string_table(mem, string_table_start):
-    """Dumps the string IDs and strings to a csv file.
+def dump_string_table(mem, string_table_start, mem_dump_start=0x00000000):
+    """
+    Dumps the string IDs and strings to a csv file.
     The string table is an array list of id/string pointer pairs.
-    The strings are null terminated and the end of the array will be marked by a null pointer."""
+    """
 
-    with open("string_table.csv", "w+", encoding="iso-8859-1") as file:
-        file.write("id,string\n")
-        
+    with open("strings.csv", "w+", encoding="utf-8") as file:
         cur = string_table_start
         i = 0
 
@@ -18,18 +18,17 @@ def dump_string_table(mem, string_table_start):
 
             id, pointer = int.from_bytes(mem[cur:cur+4], "little"), int.from_bytes(mem[cur+4:cur+8], "little")
             print(f"{id:X}, {pointer:X}")
-            if pointer == 0x000000 or i > 500:
+            if (pointer == 0x000000) or (id > 0xFFFF) or (i > 1000):
                 break
-            pointer = pointer - 0x4BA440
+            pointer = pointer - mem_dump_start
             
             string = ""
             while True:
-                # subtract 0x4BA440 from the pointer to get the offset in the file
-
-                char = mem[pointer:pointer+1]
-                if char == b"\x00" or char == b'':
+                byte = mem[pointer:pointer+1]
+                if byte == b"\x00" or byte == b'':
                     break
-                string += char.decode("iso-8859-1")
+                char = byte.decode("iso-8859-1")
+                string += char
                 pointer += 1
 
             # check if string contains quotation marks, commas, or newlines
@@ -37,15 +36,20 @@ def dump_string_table(mem, string_table_start):
                 # if so, wrap the string in quotation marks
                 string = f"\"{string}\""
             file.write(f"{id},{string}\n")
-            cur += 8
-        
-def main():
-    mem = None
-    with open("mem.bin", "rb") as file:
-        mem = file.read()
-
-    dump_string_table(mem, STRING_TABLE_START)
-        
+            cur += 8        
 
 if __name__ == "__main__":
-    main()
+    # get the command line arguments
+    parser = argparse.ArgumentParser(description="Extracts the string table from a memory dump to a csv file.")
+    parser.add_argument("mem_file", help="The memory dump file.")
+    parser.add_argument("offset", help="The start of the string table.", type=lambda x: int(x, 16))
+    parser.add_argument("-s", "--start", help="The start of the memory dump.", type=lambda x: int(x, 16), default=0x00000000)
+    args = parser.parse_args()
+
+    # read the memory dump
+    memory = None
+    with open(args.mem_file, "rb") as file:
+        memory = file.read()
+
+    # dump the string table
+    dump_string_table(memory, args.offset, args.start)


### PR DESCRIPTION
This PR adds to and updates the scripts in the utils directory:
* The `dump_string_table.py` script now works with any PS2 mem dump so long as you know the offset of the dump from the EE memory base, and the offset of the string table within the mem dump.
* The new script `check_pnach_compat.py` checks if two pnach files are compatible with each other. Two pnach files are compatible if they don't write to the same memory address. Currently the script only check 32-bit constant writes and does not account for conditional checks.